### PR TITLE
Remove Bundler dependency and update RSpec

### DIFF
--- a/greeklish.gemspec
+++ b/greeklish.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.1.0"
+  spec.add_development_dependency "rspec", "~> 3.9"
 end


### PR DESCRIPTION
This PR aims to fix problems that may arise with Ruby 2.5.